### PR TITLE
✨ Study boolean

### DIFF
--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -1,0 +1,8 @@
+export {};
+
+let name = 'Typescript'
+
+let isFinished: boolean = true;
+isFinished = false;
+// isFinished = 1;
+console.log({isFinished});


### PR DESCRIPTION
`export {};` とかして、そのファイルで何かしらをexportしておかないと、そのファイルで定義している変数がグローバル空間にすでにある何かしらの変数とかぶってしまってエラーが起こる可能性がある